### PR TITLE
Fix "unused" warning and potential inefficiency

### DIFF
--- a/shader_code/clike_language.h
+++ b/shader_code/clike_language.h
@@ -163,7 +163,7 @@ namespace shader_code
 
 				std::string new_mask;
 
-				using sw = std::string[]; sw{ (new_mask += mask.substr(channels, 1))... };
+				using sw = int[]; static_cast<void>(sw{ 0, (new_mask += mask.substr(channels, 1), 0)... });
 
 				return{ !is_single ? "(" + text + ")" : text, new_mask, is_single, base_count };
 			}
@@ -560,7 +560,7 @@ namespace shader_code
 			{
 				std::string result;
 
-				using sw = std::string[]; sw{ (result += (result.empty() ? "" : ", ") + args.finalize(false))..., "" };
+				using sw = int[]; static_cast<void>(sw{ 0, (result += (result.empty() ? "" : ", ") + args.finalize(false), 0)...});
 
 				return{ std::string(NameType::name) + "(" + result + ")" };
 			}
@@ -575,7 +575,7 @@ namespace shader_code
 			{
 				std::string result = std::string(NameType::name) + "(";
 
-				using sw = std::string[]; sw{ (result += args.to_string())..., "" };
+				using sw = int[]; static_cast<void>(sw{ 0, (result += args.to_string(), 0)...});
 
 				return{ result + ")" };
 			}


### PR DESCRIPTION
clang 3.6.0 seems to recognize pattern and optimize int[] creation just fine:
https://goo.gl/9uPGla

While it generates x1.7 as much code with std::string : https://goo.gl/yWVMTa
(~180 against ~300 lines of asm).
For gcc 4.9.2 it's 73 against 200.
