### PR TITLE
rsx_decompiler: completely ignore src swizzle mask if disable_swizzle_as_dst is set

### DIFF
--- a/rsx_decompiler/rsx_fp_decompiler.cpp
+++ b/rsx_decompiler/rsx_fp_decompiler.cpp
@@ -522,11 +522,11 @@ namespace rsx
 
 							for (std::pair<int, int> channels : entry.second)
 							{
-								src_swizzle += src.swizzle(flags & disable_swizzle_as_dst ? channels.second : channels.first).mask[0];
+								src_swizzle += src.swizzle(channels.first).mask[0];
 								dst_swizzle += dest.swizzle(channels.second).mask[0];
 							}
 
-							float_point_expr<4> expression{ src.with_mask(src_swizzle) };
+							float_point_expr<4> expression{ (flags & disable_swizzle_as_dst)? src: src.with_mask(src_swizzle) };
 
 							if (!instruction.data.dst.no_dest)
 							{


### PR DESCRIPTION
When executing conditional instructions, the src parameter was still being swizzled despite the disable_swizzle flag being set. This PR rectifies this behaviour and should fix several outstanding compilation problems with the recompiler as they are all somewhat linked to this.
